### PR TITLE
Update merge package to a more secure dependecy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "debug": "*",
     "jsonfile" : "2.0.0",
-    "merge": "1.2.0"
+    "merge": "^2.1.1"
   },
   "devDependecies":{
     "mocha": "*"


### PR DESCRIPTION
From npm audit:

merge  <=2.1.0
Severity: high
Prototype Pollution in merge - https://github.com/advisories/GHSA-7wpw-2hjm-89gp
Prototype Pollution in merge - https://github.com/advisories/GHSA-f9cm-qmx5-m98h
No fix available
node_modules/merge
  full-text-search  *
  Depends on vulnerable versions of merge
  node_modules/full-text-search